### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ git push -u origin main
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/#nolangz/pixel2motion&Date">
-    <img src="https://api.star-history.com/svg?repos=nolangz/pixel2motion&type=Date" width="720" alt="Pixel2Motion GitHub star history chart">
+  <a href="https://star-history.dera.page/#nolangz/pixel2motion&type=date">
+    <img src="https://star-history.dera.page/svg?repos=nolangz/pixel2motion&type=Date" width="720" alt="Pixel2Motion GitHub star history chart">
   </a>
   <br>
   <sub>Classic hand-drawn growth curve for Pixel2Motion GitHub stars.</sub>


### PR DESCRIPTION
The current Star History chart is broken, so update the chart links to restore the repository's star history display.